### PR TITLE
Fix GAE deploy workflow auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,9 +17,12 @@ jobs:
         run: |
           cd frontend && npm ci && npm run build
           cd ../backend && npm ci
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
       - uses: google-github-actions/setup-gcloud@v2
         with:
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
           project_id: ${{ secrets.GCP_PROJECT }}
       - name: Deploy
         run: gcloud app deploy --quiet


### PR DESCRIPTION
## Summary
- authenticate to Google Cloud using `google-github-actions/auth`

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68c7508ad7d48326b985cfc15cb9ec09