### PR TITLE
Ensure App Engine is created before deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,5 +24,9 @@ jobs:
       - uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GCP_PROJECT }}
+      - name: Ensure App Engine app
+        run: |
+          gcloud app describe --project="${{ secrets.GCP_PROJECT }}" > /dev/null 2>&1 || \
+          gcloud app create --project="${{ secrets.GCP_PROJECT }}" --region="${{ secrets.GCP_REGION }}" --quiet
       - name: Deploy
         run: gcloud app deploy --quiet


### PR DESCRIPTION
## Summary
- verify App Engine app exists before running `gcloud app deploy`

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c75203f4508326b9e721cdf65bd249