### PR TITLE
Ensure App Engine is created before deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,5 +24,10 @@ jobs:
       - uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GCP_PROJECT }}
+      - name: Ensure App Engine app
+        run: |
+          if ! gcloud app describe --project="${{ secrets.GCP_PROJECT }}" >/dev/null 2>&1; then
+            gcloud app create --project="${{ secrets.GCP_PROJECT }}" --region="${{ secrets.GCP_REGION }}" --quiet
+          fi
       - name: Deploy
         run: gcloud app deploy --quiet

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ docker run -p 8080:8080 --env-file backend/.env chat-app
 
 ## Deployment
 
-This repo includes `app.yaml` and a GitHub Actions workflow for deploying to Google App Engine. Configure `GCP_PROJECT` and `GCP_SA_KEY` secrets in your repository, then push to the `work` branch to trigger deployment.
+This repo includes `app.yaml` and a GitHub Actions workflow for deploying to Google App Engine. Configure `GCP_PROJECT`, `GCP_SA_KEY`, and `GCP_REGION` secrets in your repository, then push to the `main` branch to trigger deployment.


### PR DESCRIPTION
## Summary
- ensure App Engine exists before deployment and explicitly provide region
- document GCP_REGION secret required for deployment

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c75203f4508326b9e721cdf65bd249