### PR TITLE
Write env vars to app.yaml in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,16 @@ jobs:
           if ! gcloud app describe --project="${{ secrets.GCP_PROJECT }}" >/dev/null 2>&1; then
             gcloud app create --project="${{ secrets.GCP_PROJECT }}" --region="${{ secrets.GCP_REGION }}" --quiet
           fi
+      - name: Configure app.yaml
+        run: |
+          cat > app.yaml <<EOF
+          runtime: custom
+          env: flex
+          env_variables:
+            GCS_BUCKET: "$GCS_BUCKET"
+            JWT_REFRESH: "$JWT_REFRESH"
+            JWT_SECRET: "$JWT_SECRET"
+            MONGO_URI: "$MONGO_URI"
+          EOF
       - name: Deploy
-        run: >-
-          gcloud app deploy --quiet --set-env-vars \
-          "GCS_BUCKET=$GCS_BUCKET,JWT_REFRESH=$JWT_REFRESH,JWT_SECRET=$JWT_SECRET,MONGO_URI=$MONGO_URI"
+        run: gcloud app deploy app.yaml --quiet


### PR DESCRIPTION
## Summary
- generate app.yaml with env vars from secrets prior to deployment
- deploy App Engine app without --set-env-vars

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c76200eba483269073fc3badf42746