### PR TITLE
Fix Express catch-all route wildcard

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -20,7 +20,9 @@ app.use('/api/users', userRoutes);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 app.use(express.static(path.join(__dirname, '../frontend/dist')));
-app.get('*', (req, res) => {
+// Express 5 uses path-to-regexp v6, which disallows bare '*' wildcards.
+// Use a named parameter with a repeating modifier to implement a catch-all route.
+app.get('/:path*', (req, res) => {
   res.sendFile(path.join(__dirname, '../frontend/dist/index.html'));
 });
 


### PR DESCRIPTION
## Summary
- Replace bare `*` route with named wildcard to avoid path-to-regexp error on deploy
- Add comment clarifying Express 5 wildcard usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c76535dff48326a739a90fedd02081