### PR TITLE
fix: remove deprecated mongoose options

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -26,7 +26,7 @@ app.get('/{*path}', (req, res) => {
   res.sendFile(path.join(__dirname, '../frontend/dist/index.html'));
 });
 
-mongoose.connect(process.env.MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true })
+mongoose.connect(process.env.MONGO_URI)
   .then(() => {
     app.listen(PORT, () => console.log(`Server running on ${PORT}`));
   })


### PR DESCRIPTION
## Summary
- remove deprecated mongoose connection options

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c76f3cf7488326aaf728ae3cb8257a