### PR TITLE
docs: configure chat database name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cp backend/.env.example backend/.env
 
 Set the following variables:
 
-- `MONGO_URI` – connection string to external MongoDB
+- `MONGO_URI` – connection string to external MongoDB (e.g., `mongodb://localhost:27017/chat`)
 - `JWT_SECRET` – secret for access tokens
 - `JWT_REFRESH` – secret for refresh tokens
 - `GCS_BUCKET` – Google Cloud Storage bucket for avatars

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,4 @@
-MONGO_URI=mongodb://localhost:27017/chatapp
+MONGO_URI=mongodb://localhost:27017/chat
 JWT_SECRET=your_jwt_secret
 JWT_REFRESH=your_refresh_secret
 GCS_BUCKET=your-bucket-name


### PR DESCRIPTION
## Summary
- use `chat` database in example env
- note chat database in README environment setup

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c780da6da08326b154142297f9f980