### PR TITLE
Use toast notifications for errors and user feedback

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, useRef } from 'react';
 import { getProfile, uploadAvatar } from '../api.js';
-import { Container, Typography, Avatar, Button } from '@mui/material';
+import { Container, Typography, Avatar, Button, Snackbar, Alert } from '@mui/material';
 
 export default function Dashboard() {
   const [user, setUser] = useState(null);
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [toast, setToast] = useState({ open: false, message: '', severity: 'info' });
   const fileInput = useRef();
 
   useEffect(() => {
@@ -12,8 +14,12 @@ export default function Dashboard() {
       try {
         const data = await getProfile();
         setUser(data);
+        setError('');
       } catch (err) {
         setError('Failed to load profile');
+        setToast({ open: true, message: 'Failed to load profile', severity: 'error' });
+      } finally {
+        setLoading(false);
       }
     };
     fetchProfile();
@@ -25,30 +31,59 @@ export default function Dashboard() {
       try {
         const updated = await uploadAvatar(file);
         setUser(updated);
+        setError('');
+        setToast({ open: true, message: 'Avatar updated', severity: 'success' });
       } catch (err) {
         setError('Upload failed');
+        setToast({ open: true, message: 'Upload failed', severity: 'error' });
+      } finally {
+        if (fileInput.current) {
+          fileInput.current.value = '';
+        }
       }
     }
   };
 
   const handleUploadClick = () => {
-    fileInput.current.click();
+    fileInput.current?.click();
   };
 
-  if (error) return <Typography color="error">{error}</Typography>;
-  if (!user) return <Typography>Loading...</Typography>;
+  const handleToastClose = (_, reason) => {
+    if (reason === 'clickaway') return;
+    setToast(prev => ({ ...prev, open: false }));
+  };
 
   return (
     <Container sx={{ mt: 4 }}>
       <Typography variant="h5">Dashboard</Typography>
-      <Typography>{user.email}</Typography>
-      {user.avatarUrl && (
-        <Avatar src={user.avatarUrl} alt="avatar" sx={{ width: 100, height: 100, my: 2 }} />
+      {loading && <Typography>Loading...</Typography>}
+      {!loading && error && (
+        <Typography color="error" sx={{ mt: 2 }}>
+          {error}
+        </Typography>
       )}
-      <input type="file" ref={fileInput} onChange={handleFile} style={{ display: 'none' }} />
-      <Button variant="contained" onClick={handleUploadClick} sx={{ mt: 2 }}>
-        Upload Avatar
-      </Button>
+      {!loading && user && (
+        <>
+          <Typography>{user.email}</Typography>
+          {user.avatarUrl && (
+            <Avatar src={user.avatarUrl} alt="avatar" sx={{ width: 100, height: 100, my: 2 }} />
+          )}
+          <input type="file" ref={fileInput} onChange={handleFile} style={{ display: 'none' }} />
+          <Button variant="contained" onClick={handleUploadClick} sx={{ mt: 2 }}>
+            Upload Avatar
+          </Button>
+        </>
+      )}
+      <Snackbar
+        open={toast.open}
+        autoHideDuration={4000}
+        onClose={handleToastClose}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      >
+        <Alert onClose={handleToastClose} severity={toast.severity} variant="filled" sx={{ width: '100%' }}>
+          {toast.message}
+        </Alert>
+      </Snackbar>
     </Container>
   );
 }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import { login } from '../api.js';
 import { useNavigate } from 'react-router-dom';
-import { Container, TextField, Button, Typography, Box } from '@mui/material';
+import { Container, TextField, Button, Typography, Box, Snackbar, Alert } from '@mui/material';
 
 export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
+  const [toast, setToast] = useState({ open: false, message: '', severity: 'error' });
   const navigate = useNavigate();
 
   const handleSubmit = async e => {
@@ -15,23 +15,33 @@ export default function Login() {
       await login(email, password);
       navigate('/dashboard');
     } catch (err) {
-      setError('Invalid credentials');
+      setToast({ open: true, message: 'Invalid credentials', severity: 'error' });
     }
+  };
+
+  const handleToastClose = (_, reason) => {
+    if (reason === 'clickaway') return;
+    setToast(prev => ({ ...prev, open: false }));
   };
 
   return (
     <Container maxWidth="sm">
       <Box component="form" onSubmit={handleSubmit} sx={{ mt: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
         <Typography variant="h5">Login</Typography>
-        {error && (
-          <Typography color="error">
-            {error}
-          </Typography>
-        )}
         <TextField label="Email" value={email} onChange={e => setEmail(e.target.value)} fullWidth />
         <TextField type="password" label="Password" value={password} onChange={e => setPassword(e.target.value)} fullWidth />
         <Button type="submit" variant="contained">Login</Button>
       </Box>
+      <Snackbar
+        open={toast.open}
+        autoHideDuration={4000}
+        onClose={handleToastClose}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      >
+        <Alert onClose={handleToastClose} severity={toast.severity} variant="filled" sx={{ width: '100%' }}>
+          {toast.message}
+        </Alert>
+      </Snackbar>
     </Container>
   );
 }

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,38 +1,48 @@
 import { useState } from 'react';
 import { register } from '../api.js';
 import { useNavigate } from 'react-router-dom';
-import { Container, TextField, Button, Typography, Box } from '@mui/material';
+import { Container, TextField, Button, Typography, Box, Snackbar, Alert } from '@mui/material';
 
 export default function Register() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [message, setMessage] = useState('');
+  const [toast, setToast] = useState({ open: false, message: '', severity: 'info' });
   const navigate = useNavigate();
 
   const handleSubmit = async e => {
     e.preventDefault();
     try {
       await register(email, password);
-      setMessage('Registered, please login');
+      setToast({ open: true, message: 'Registered, please login', severity: 'success' });
       setTimeout(() => navigate('/login'), 1000);
     } catch (err) {
-      setMessage('Registration failed');
+      setToast({ open: true, message: 'Registration failed', severity: 'error' });
     }
+  };
+
+  const handleToastClose = (_, reason) => {
+    if (reason === 'clickaway') return;
+    setToast(prev => ({ ...prev, open: false }));
   };
 
   return (
     <Container maxWidth="sm">
       <Box component="form" onSubmit={handleSubmit} sx={{ mt: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
         <Typography variant="h5">Register</Typography>
-        {message && (
-          <Typography color="primary">
-            {message}
-          </Typography>
-        )}
         <TextField label="Email" value={email} onChange={e => setEmail(e.target.value)} fullWidth />
         <TextField type="password" label="Password" value={password} onChange={e => setPassword(e.target.value)} fullWidth />
         <Button type="submit" variant="contained">Register</Button>
       </Box>
+      <Snackbar
+        open={toast.open}
+        autoHideDuration={4000}
+        onClose={handleToastClose}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      >
+        <Alert onClose={handleToastClose} severity={toast.severity} variant="filled" sx={{ width: '100%' }}>
+          {toast.message}
+        </Alert>
+      </Snackbar>
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
- replace inline login error message with a toast notification
- show registration success and failure feedback through toasts
- add dashboard toasts for profile loading and avatar upload results

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8ada68494832684c7db873ef9c22a