### PR TITLE
Add Stripe subscription system

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,27 @@ Set the following variables:
 - `JWT_SECRET` – secret for access tokens
 - `JWT_REFRESH` – secret for refresh tokens
 - `GCS_BUCKET` – Google Cloud Storage bucket for avatars
+- `STRIPE_SECRET_KEY` – Stripe secret key used by the backend API
+- `STRIPE_PRICE_ID` – ID of the recurring price to sell via subscriptions
+- `STRIPE_WEBHOOK_SECRET` – signing secret for the Stripe webhook endpoint (recommended)
+- `CLIENT_URL` – optional base URL for redirecting after checkout (falls back to request origin)
+
+For the frontend, create `frontend/.env` and expose your publishable key:
+
+```
+VITE_STRIPE_PUBLISHABLE_KEY=pk_test_1234
+```
+
+### Stripe Webhooks
+
+When running locally, forward Stripe webhooks to the development server so subscription updates
+are reflected in MongoDB:
+
+```
+stripe listen --forward-to localhost:8080/api/subscriptions/webhook
+```
+
+Copy the webhook signing secret from the command output into `STRIPE_WEBHOOK_SECRET`.
 
 ## Development
 

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -9,7 +9,11 @@ const userSchema = new mongoose.Schema({
     type: String,
     enum: ['user', 'admin'],
     default: 'user'
-  }
+  },
+  stripeCustomerId: { type: String },
+  stripeSubscriptionId: { type: String },
+  subscriptionStatus: { type: String },
+  subscriptionCurrentPeriodEnd: { type: Date }
 }, { timestamps: true });
 
 export default mongoose.model('User', userSchema);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,8 @@
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.18.1",
-        "multer": "^2.0.2"
+        "multer": "^2.0.2",
+        "stripe": "^18.5.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.10"
@@ -2274,6 +2275,26 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "18.5.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.5.0.tgz",
+      "integrity": "sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/strnum": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,8 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.18.1",
-    "multer": "^2.0.2"
+    "multer": "^2.0.2",
+    "stripe": "^18.5.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/backend/routes/subscription.js
+++ b/backend/routes/subscription.js
@@ -1,0 +1,227 @@
+import { Router } from 'express';
+import Stripe from 'stripe';
+import auth from '../middleware/auth.js';
+import User from '../models/User.js';
+
+const router = Router();
+
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const stripe = stripeSecretKey
+  ? new Stripe(stripeSecretKey, { apiVersion: '2024-06-20' })
+  : null;
+
+const ensureStripeConfigured = () => {
+  if (!stripe) {
+    const error = new Error('Stripe is not configured');
+    error.statusCode = 500;
+    throw error;
+  }
+};
+
+const getBaseUrl = req => process.env.CLIENT_URL || req.headers.origin || `${req.protocol}://${req.get('host')}`;
+
+const getDefaultDashboardUrl = req => {
+  const baseUrl = getBaseUrl(req);
+  return baseUrl.endsWith('/dashboard') ? baseUrl : `${baseUrl.replace(/\/$/, '')}/dashboard`;
+};
+
+const SUBSCRIPTION_ACTIVE_STATUSES = new Set(['active', 'trialing', 'past_due', 'incomplete']);
+
+router.get('/status', auth, async (req, res) => {
+  try {
+    const user = await User.findById(req.userId).select(
+      'stripeCustomerId stripeSubscriptionId subscriptionStatus subscriptionCurrentPeriodEnd'
+    );
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    res.json({
+      stripeCustomerId: user.stripeCustomerId || null,
+      stripeSubscriptionId: user.stripeSubscriptionId || null,
+      subscriptionStatus: user.subscriptionStatus || null,
+      subscriptionCurrentPeriodEnd: user.subscriptionCurrentPeriodEnd || null
+    });
+  } catch (err) {
+    console.error('Failed to load subscription status', err);
+    res.status(500).json({ message: 'Failed to load subscription status' });
+  }
+});
+
+router.post('/checkout-session', auth, async (req, res) => {
+  try {
+    ensureStripeConfigured();
+
+    const priceId = req.body?.priceId || process.env.STRIPE_PRICE_ID;
+    if (!priceId) {
+      return res.status(500).json({ message: 'Stripe price is not configured' });
+    }
+
+    const user = req.user;
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+
+    if (user.subscriptionStatus && SUBSCRIPTION_ACTIVE_STATUSES.has(user.subscriptionStatus)) {
+      return res.status(400).json({ message: 'You already have an active subscription' });
+    }
+
+    let customerId = user.stripeCustomerId;
+    if (!customerId) {
+      const customer = await stripe.customers.create({
+        email: user.email,
+        metadata: { userId: user._id.toString() }
+      });
+      customerId = customer.id;
+      user.stripeCustomerId = customerId;
+      await user.save();
+    }
+
+    const successUrl = `${getDefaultDashboardUrl(req)}?session_id={CHECKOUT_SESSION_ID}`;
+    const cancelUrl = getDefaultDashboardUrl(req);
+
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      customer: customerId,
+      line_items: [
+        {
+          price: priceId,
+          quantity: 1
+        }
+      ],
+      allow_promotion_codes: true,
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+      metadata: {
+        userId: user._id.toString()
+      }
+    });
+
+    res.json({ id: session.id, url: session.url });
+  } catch (err) {
+    const status = err.statusCode || 500;
+    const message = err.statusCode ? err.message : 'Failed to create checkout session';
+    console.error(message, err);
+    res.status(status).json({ message });
+  }
+});
+
+router.post('/portal-session', auth, async (req, res) => {
+  try {
+    ensureStripeConfigured();
+
+    const user = req.user;
+    if (!user?.stripeCustomerId) {
+      return res.status(400).json({ message: 'No Stripe customer found for this user' });
+    }
+
+    const session = await stripe.billingPortal.sessions.create({
+      customer: user.stripeCustomerId,
+      return_url: getDefaultDashboardUrl(req)
+    });
+
+    res.json({ url: session.url });
+  } catch (err) {
+    const status = err.statusCode || 500;
+    const message = err.statusCode ? err.message : 'Failed to create billing portal session';
+    console.error(message, err);
+    res.status(status).json({ message });
+  }
+});
+
+async function updateUserFromSubscription(subscription) {
+  if (!subscription?.customer) return;
+
+  const query = { stripeCustomerId: subscription.customer };
+  const update = {
+    stripeCustomerId: subscription.customer,
+    subscriptionStatus: subscription.status || null,
+    subscriptionCurrentPeriodEnd: subscription.current_period_end
+      ? new Date(subscription.current_period_end * 1000)
+      : null
+  };
+
+  if (subscription.status === 'canceled' || subscription.status === 'incomplete_expired') {
+    update.stripeSubscriptionId = null;
+  } else if (subscription.id) {
+    update.stripeSubscriptionId = subscription.id;
+  }
+
+  await User.findOneAndUpdate(query, update, { new: true }).catch(err => {
+    console.error('Failed to update user subscription data', err);
+  });
+}
+
+async function updateUserFromCheckout(session) {
+  if (!session?.customer) return;
+
+  const query = [
+    { stripeCustomerId: session.customer },
+    session.customer_details?.email ? { email: session.customer_details.email.toLowerCase() } : null
+  ].filter(Boolean);
+
+  const user = await User.findOne({ $or: query }).catch(err => {
+    console.error('Failed to locate user for checkout session', err);
+    return null;
+  });
+
+  if (!user) {
+    return;
+  }
+
+  user.stripeCustomerId = session.customer;
+  if (session.subscription) {
+    user.stripeSubscriptionId = typeof session.subscription === 'string'
+      ? session.subscription
+      : session.subscription.id;
+  }
+
+  await user.save().catch(err => {
+    console.error('Failed to persist checkout session updates', err);
+  });
+}
+
+export async function stripeWebhookHandler(req, res) {
+  try {
+    ensureStripeConfigured();
+  } catch (err) {
+    console.error('Stripe webhook received but Stripe is not configured');
+    return res.status(500).send('Stripe not configured');
+  }
+
+  const signature = req.headers['stripe-signature'];
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+  let event;
+  try {
+    if (webhookSecret) {
+      event = stripe.webhooks.constructEvent(req.body, signature, webhookSecret);
+    } else {
+      event = JSON.parse(req.body.toString('utf8'));
+    }
+  } catch (err) {
+    console.error('Stripe webhook signature verification failed', err.message);
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  try {
+    switch (event.type) {
+      case 'customer.subscription.created':
+      case 'customer.subscription.updated':
+      case 'customer.subscription.deleted':
+        await updateUserFromSubscription(event.data.object);
+        break;
+      case 'checkout.session.completed':
+        await updateUserFromCheckout(event.data.object);
+        break;
+      default:
+        break;
+    }
+  } catch (err) {
+    console.error('Error handling Stripe webhook event', err);
+    return res.status(500).send('Webhook handler failure');
+  }
+
+  res.json({ received: true });
+}
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,10 +6,14 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import authRoutes from './routes/auth.js';
 import userRoutes from './routes/user.js';
+import subscriptionRoutes, { stripeWebhookHandler } from './routes/subscription.js';
 
 dotenv.config();
 
 const app = express();
+
+app.post('/api/subscriptions/webhook', express.raw({ type: 'application/json' }), stripeWebhookHandler);
+
 app.use(express.json());
 app.use(cookieParser());
 
@@ -17,6 +21,7 @@ const PORT = process.env.PORT || 8080;
 
 app.use('/api/auth', authRoutes);
 app.use('/api/users', userRoutes);
+app.use('/api/subscriptions', subscriptionRoutes);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 app.use(express.static(path.join(__dirname, '../frontend/dist')));

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.3.2",
         "@mui/material": "^7.3.2",
+        "@stripe/stripe-js": "^7.9.0",
         "axios": "^1.6.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1444,6 +1445,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.9.0.tgz",
+      "integrity": "sha512-ggs5k+/0FUJcIgNY08aZTqpBTtbExkJMYMLSMwyucrhtWexVOEY1KJmhBsxf+E/Q15f5rbwBpj+t0t2AW2oCsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.2",
+    "@stripe/stripe-js": "^7.9.0",
     "axios": "^1.6.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -116,4 +116,20 @@ export const updateUserRole = async (id, role) => {
   return data;
 };
 
+export const getSubscriptionStatus = async () => {
+  const { data } = await api.get('/subscriptions/status');
+  return data;
+};
+
+export const createCheckoutSession = async priceId => {
+  const payload = priceId ? { priceId } : {};
+  const { data } = await api.post('/subscriptions/checkout-session', payload);
+  return data;
+};
+
+export const createBillingPortalSession = async () => {
+  const { data } = await api.post('/subscriptions/portal-session');
+  return data;
+};
+
 export default api;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,15 +1,34 @@
-import { useState, useEffect, useRef } from 'react';
-import { getProfile, uploadAvatar } from '../api.js';
-import { Container, Typography, Avatar, Button, Snackbar, Alert } from '@mui/material';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import {
+  getProfile,
+  uploadAvatar,
+  createCheckoutSession,
+  createBillingPortalSession,
+  getSubscriptionStatus
+} from '../api.js';
+import { Container, Typography, Avatar, Button, Snackbar, Alert, Box } from '@mui/material';
+import { getStripe } from '../stripe.js';
 
 const MAX_AVATAR_SIZE_MB = 5;
 const MAX_AVATAR_SIZE_BYTES = MAX_AVATAR_SIZE_MB * 1024 * 1024;
+const ACTIVE_SUBSCRIPTION_STATUSES = new Set(['active', 'trialing', 'past_due', 'incomplete']);
+
+const formatSubscriptionStatus = status => {
+  if (!status) return 'Not subscribed';
+  return status
+    .replace(/_/g, ' ')
+    .split(' ')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};
 
 export default function Dashboard() {
   const [user, setUser] = useState(null);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
   const [toast, setToast] = useState({ open: false, message: '', severity: 'info' });
+  const [subscriptionLoading, setSubscriptionLoading] = useState(false);
+  const [portalLoading, setPortalLoading] = useState(false);
   const fileInput = useRef();
 
   useEffect(() => {
@@ -27,6 +46,42 @@ export default function Dashboard() {
     };
     fetchProfile();
   }, []);
+
+  const refreshSubscription = useCallback(async () => {
+    try {
+      const status = await getSubscriptionStatus();
+      setUser(prev => (prev ? { ...prev, ...status } : prev));
+      return status;
+    } catch (err) {
+      throw err;
+    }
+  }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const sessionId = params.get('session_id');
+    if (!sessionId) return;
+
+    const finalizeCheckout = async () => {
+      try {
+        await refreshSubscription();
+        setToast({ open: true, message: 'Subscription updated successfully', severity: 'success' });
+      } catch (err) {
+        setToast({
+          open: true,
+          message: 'Subscription is processing. Refresh in a moment.',
+          severity: 'info'
+        });
+      } finally {
+        params.delete('session_id');
+        const newSearch = params.toString();
+        const newUrl = `${window.location.pathname}${newSearch ? `?${newSearch}` : ''}`;
+        window.history.replaceState({}, '', newUrl);
+      }
+    };
+
+    finalizeCheckout();
+  }, [refreshSubscription]);
 
   const handleFile = async e => {
     const file = e.target.files[0];
@@ -72,6 +127,51 @@ export default function Dashboard() {
     fileInput.current?.click();
   };
 
+  const handleSubscribe = async () => {
+    setSubscriptionLoading(true);
+    try {
+      const { id, url } = await createCheckoutSession();
+      const stripe = await getStripe();
+      if (stripe && id) {
+        const { error: stripeError } = await stripe.redirectToCheckout({ sessionId: id });
+        if (stripeError) {
+          throw stripeError;
+        }
+      } else if (url) {
+        window.location.href = url;
+      } else {
+        throw new Error('Unable to start checkout session');
+      }
+    } catch (err) {
+      const message = err.response?.data?.message || err.message || 'Failed to start checkout';
+      setToast({ open: true, message, severity: 'error' });
+    } finally {
+      setSubscriptionLoading(false);
+    }
+  };
+
+  const handleManageSubscription = async () => {
+    setPortalLoading(true);
+    try {
+      const { url } = await createBillingPortalSession();
+      if (url) {
+        window.location.href = url;
+      } else {
+        throw new Error('Unable to open billing portal');
+      }
+    } catch (err) {
+      const message = err.response?.data?.message || err.message || 'Failed to open billing portal';
+      setToast({ open: true, message, severity: 'error' });
+    } finally {
+      setPortalLoading(false);
+    }
+  };
+
+  const hasActiveSubscription = user && ACTIVE_SUBSCRIPTION_STATUSES.has(user.subscriptionStatus);
+  const renewalDate = user?.subscriptionCurrentPeriodEnd
+    ? new Date(user.subscriptionCurrentPeriodEnd)
+    : null;
+
   const handleToastClose = (_, reason) => {
     if (reason === 'clickaway') return;
     setToast(prev => ({ ...prev, open: false }));
@@ -105,6 +205,38 @@ export default function Dashboard() {
           <Button variant="contained" onClick={handleUploadClick} sx={{ mt: 2 }}>
             Upload Avatar
           </Button>
+          <Box sx={{ mt: 4 }}>
+            <Typography variant="h6" gutterBottom>
+              Subscription
+            </Typography>
+            <Typography>
+              Status: {formatSubscriptionStatus(user.subscriptionStatus)}
+            </Typography>
+            {renewalDate && (
+              <Typography variant="body2" sx={{ color: 'text.secondary', mt: 0.5 }}>
+                Renews on {renewalDate.toLocaleString()}
+              </Typography>
+            )}
+            {hasActiveSubscription ? (
+              <Button
+                variant="outlined"
+                onClick={handleManageSubscription}
+                sx={{ mt: 2 }}
+                disabled={portalLoading}
+              >
+                {portalLoading ? 'Opening...' : 'Manage Subscription'}
+              </Button>
+            ) : (
+              <Button
+                variant="contained"
+                onClick={handleSubscribe}
+                sx={{ mt: 2 }}
+                disabled={subscriptionLoading}
+              >
+                {subscriptionLoading ? 'Redirecting...' : 'Subscribe'}
+              </Button>
+            )}
+          </Box>
         </>
       )}
       <Snackbar

--- a/frontend/src/stripe.js
+++ b/frontend/src/stripe.js
@@ -1,0 +1,14 @@
+import { loadStripe } from '@stripe/stripe-js';
+
+let stripePromise;
+
+export const getStripe = () => {
+  if (!stripePromise) {
+    const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY;
+    if (!publishableKey) {
+      throw new Error('Stripe publishable key is not configured');
+    }
+    stripePromise = loadStripe(publishableKey);
+  }
+  return stripePromise;
+};


### PR DESCRIPTION
## Summary
- add Stripe-powered subscription API with checkout session creation, billing portal access, and webhook handling
- persist subscription metadata on user records and expose subscription status endpoints
- refresh the dashboard UI to drive Stripe checkout/portal flows and document required Stripe environment variables

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68c99a591ec08326a9da9b633102509a